### PR TITLE
chore: Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # See https://git-scm.com/docs/gitattributes for more about git attribute files.
-* text=auto
+* text=crlf
 
 
 # Mark the database schema as having been generated.


### PR DESCRIPTION
Changed gitattributes to always use crlf, since we use dev containers on windows, so it should always be consistent with Unix formats.