### PR TITLE
Add Codex environment setup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -473,13 +473,14 @@ except Exception as e:
 
 When working with this codebase:
 
-1. **Follow Existing Patterns**: Match the established code organization and style
-2. **Respect API Contracts**: Never break Agent API v1 compatibility
-3. **Use Proper Tools**: Use the specified libraries (loguru, cashews, etc.)
-4. **Validate Changes**: Always run `just ci-check` before completing tasks
-5. **Security First**: Follow security guidelines for all code changes
-6. **Test Thoroughly**: Write and run appropriate tests for all changes
-7. **Document Changes**: Update relevant documentation when making changes
+1. **Initialize your environment**: After cloning the repository, run `./scripts/setup_codex_env.sh` to install required packages and dependencies.
+2. **Follow Existing Patterns**: Match the established code organization and style
+3. **Respect API Contracts**: Never break Agent API v1 compatibility
+4. **Use Proper Tools**: Use the specified libraries (loguru, cashews, etc.)
+5. **Validate Changes**: Always run `just ci-check` before completing tasks
+6. **Security First**: Follow security guidelines for all code changes
+7. **Test Thoroughly**: Write and run appropriate tests for all changes
+8. **Document Changes**: Update relevant documentation when making changes
 
 ### Common Pitfalls to Avoid
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -26,7 +26,13 @@ This guide covers setting up your development environment for CipherSwarm.
     cd cipherswarm
     ```
 
-2. **Create Virtual Environment**
+2. **Run the Codex environment setup script**
+
+    ```bash
+    ./scripts/setup_codex_env.sh
+    ```
+
+3. **Create Virtual Environment**
 
     ```bash
     python3.13 -m venv .venv
@@ -35,7 +41,7 @@ This guide covers setting up your development environment for CipherSwarm.
     .venv\Scripts\activate     # Windows
     ```
 
-3. **Install Dependencies**
+4. **Install Dependencies**
 
     ```bash
     # Install uv
@@ -45,7 +51,7 @@ This guide covers setting up your development environment for CipherSwarm.
     uv pip install -e ".[dev]"
     ```
 
-4. **Install Pre-commit Hooks**
+5. **Install Pre-commit Hooks**
 
     ```bash
     pre-commit install

--- a/scripts/setup_codex_env.sh
+++ b/scripts/setup_codex_env.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install required apt packages
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+    python3.13 python3.13-venv python3.13-dev \
+    gcc g++ make curl git docker.io
+
+# Install Node.js 20 if not present
+if ! command -v node >/dev/null || ! node -v | grep -q '^v20'; then
+    curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+    sudo apt-get install -y nodejs
+fi
+
+# Ensure pnpm is available
+sudo npm install -g pnpm
+
+# Install just if missing
+if ! command -v just >/dev/null; then
+    curl -LsSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+fi
+
+# Install uv if missing
+if ! command -v uv >/dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | bash
+fi
+
+# Sync Python dependencies
+uv sync --dev
+
+# Install frontend dependencies
+if [ -d "frontend" ]; then
+    pushd frontend >/dev/null
+    pnpm install
+    popd >/dev/null
+fi
+
+# Install pre-commit hooks
+uv run pre-commit install --hook-type commit-msg


### PR DESCRIPTION
## Summary
- add helper script `setup_codex_env.sh` to install tools and dependencies
- reference the script in development setup docs
- mention the script in AGENTS guidelines instead of README

## Testing
- `just ci-check` *(fails: integration tests error)*
- `just format` *(fails: prettier plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854d911bca88333845019e4b5b9b141