### PR TITLE
Fix Docker bundler install on Alpine (add postgresql-dev, git; verbose bundler with retries)

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -1,0 +1,26 @@
+name: Docker Build Test
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          pull: true
+          push: false
+          load: false
+          tags: cipherswarm:test

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV BUNDLE_DEPLOYMENT="1" \
 FROM base AS prebuild
 
 # Install packages needed to build gems and node modules
-RUN apk add --no-cache build-base gyp libffi-dev libpq-dev pkgconfig python3 yaml-dev
+RUN apk add --no-cache build-base gyp git libffi-dev postgresql-dev pkgconfig python3 yaml-dev
 
 
 FROM prebuild AS node
@@ -50,7 +50,7 @@ FROM prebuild AS build
 
 # Install application gems
 COPY Gemfile Gemfile.lock ./
-RUN bundle install && \
+RUN bundle install --jobs 4 --retry 3 --verbose && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
 
 # Copy node modules


### PR DESCRIPTION
- Add `postgresql-dev` and `git` to Alpine build stage to compile `pg` and handle git-sourced gems
- Use `bundle install --jobs 4 --retry 3 --verbose` for better reliability and logs
- Add PR-only Docker Build Test workflow to validate image builds on PRs

This should fix exit code 7 during `bundle install` in Docker builds.
