### PR TITLE
fix: correct project_users association name in UserDashboard

### DIFF
--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -24,7 +24,7 @@ class UserDashboard < Administrate::BaseDashboard
     last_sign_in_ip: Field::String,
     locked_at: Field::DateTime,
     name: Field::String,
-    project_user: Field::HasMany,
+    project_users: Field::HasMany,
     projects: Field::HasMany,
     remember_created_at: Field::DateTime,
     reset_password_sent_at: Field::DateTime,
@@ -64,7 +64,7 @@ class UserDashboard < Administrate::BaseDashboard
     last_sign_in_ip
     locked_at
     name
-    project_user
+    project_users
     role
     sign_in_count
     created_at
@@ -77,9 +77,8 @@ class UserDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
     name
     email
-    project_user
+    project_users
     projects
-    role
     agents
   ].freeze
 

--- a/spec/system/admin/manage_users_spec.rb
+++ b/spec/system/admin/manage_users_spec.rb
@@ -80,6 +80,26 @@ RSpec.describe "Admin user management" do
     end
   end
 
+  describe "admin edits user" do
+    let!(:user) { create(:user) }
+
+    it "successfully loads the edit form" do
+      visit edit_admin_user_path(user)
+
+      expect(page).to have_field("Name")
+      expect(page).to have_field("Email")
+    end
+
+    it "updates user information" do
+      visit edit_admin_user_path(user)
+
+      fill_in "Name", with: "updated name"
+      click_button "Update User"
+
+      expect(page).to have_content("User was successfully updated")
+    end
+  end
+
   describe "non-admin cannot access admin area" do
     let(:user) { create(:user) }
 


### PR DESCRIPTION
## Summary

- Fix `NoMethodError` when editing users in the admin panel by correcting `project_user` → `project_users` association name
- Remove `role` from form attributes (Rolify roles require different handling than enum selects)
- Add system tests for admin user edit functionality

## Root Cause

The `UserDashboard` referenced `project_user` (singular) but the User model defines `has_many :project_users` (plural). This caused a `NoMethodError` when Administrate tried to render the edit form.

## Changes

**`app/dashboards/user_dashboard.rb`:**
- Line 27: `project_user` → `project_users` in ATTRIBUTE_TYPES
- Line 67: `project_user` → `project_users` in SHOW_PAGE_ATTRIBUTES
- Line 80: `project_user` → `project_users` in FORM_ATTRIBUTES
- Removed `role` from FORM_ATTRIBUTES (pre-existing bug - configured for enum but User uses Rolify)

**`spec/system/admin/manage_users_spec.rb`:**
- Added test: `successfully loads the edit form`
- Added test: `updates user information`

## Test plan

- [x] All 1315 RSpec examples pass
- [x] All 345 request specs pass
- [x] RuboCop passes
- [x] Brakeman security scan passes
- [x] Admin can navigate to Admin → Users → Edit without error
- [x] Admin can update user information successfully

Fixes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for admin user management, including validation of the edit form interface and confirmation of successful user profile updates with appropriate system feedback.

* **Chores**
  * Refined internal consistency in system attribute mappings to ensure proper handling and representation of user-related associations throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->