### PR TITLE
fix: rescue Devise::MissingWarden instead of RuntimeError in safe_can?

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -105,10 +105,10 @@ module ApplicationHelper
   # @return [Boolean] True if authorized, false if not authorized or no user context
   def safe_can?(action, subject)
     can?(action, subject)
-  rescue Warden::NotAuthenticated, NoMethodError, RuntimeError => e
+  rescue Warden::NotAuthenticated, NoMethodError, Devise::MissingWarden => e
     # NoMethodError can occur when current_user is called without Warden
     # Warden::NotAuthenticated when Warden proxy is missing
-    # RuntimeError raised by Devise when Warden::Proxy instance is missing from request env
+    # Devise::MissingWarden raised when Warden::Proxy instance is missing from request env
     Rails.logger.debug { "[SafeAuthorization] Authorization check skipped - no user context: #{e.message}" }
     false
   end


### PR DESCRIPTION
## Summary
- Replaces overly broad `RuntimeError` rescue with `Devise::MissingWarden` in `safe_can?` helper
- Devise 4.9.4 raises `Devise::MissingWarden` (a `StandardError` subclass), not `RuntimeError`, when `Warden::Proxy` is missing from the request env
- Prevents masking unrelated runtime errors in authorization checks

Addresses review feedback from PR #589 (Copilot + CodeRabbit).

## Test plan
- [x] Verified `Devise::MissingWarden` exists and inherits from `StandardError` via `rails runner`
- [x] 619 component/request specs pass with no failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved permission validation by refining exception handling to properly detect authentication context failures, ensuring more accurate permission checks when user context is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->