### PR TITLE
test: add nil user authorization tests for Task permissions

### DIFF
--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -219,6 +219,13 @@ RSpec.describe Ability do
       it { is_expected.to be_able_to(:reassign, project_task) }
       it { is_expected.to be_able_to(:download_results, other_task) }
     end
+
+    context "when user is nil" do
+      subject(:ability) { described_class.new(nil) }
+
+      it { is_expected.not_to be_able_to(:read, project_task) }
+      it { is_expected.not_to be_able_to(:manage, project_task) }
+    end
   end
 
   describe "User permissions" do


### PR DESCRIPTION
## Summary
- Adds defense-in-depth tests verifying unauthenticated (nil) users cannot read or manage tasks
- Follows the existing nil user test pattern established in Agent permissions
- The Task authorization association chain fix (`attack: { campaign: { project_id: ... } }`) was already applied on `main`; this PR closes the gap in test coverage

Closes #497

## Test plan
- [x] `bundle exec rspec spec/models/ability_spec.rb` — all 88 examples pass
- [x] Pre-commit hooks pass (RuboCop, etc.)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for access control validation in scenarios without an active user session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->