### PR TITLE
fix: scope broad exception handlers to production and remove NoMethodError rescue

### DIFF
--- a/spec/requests/api/v1/client/attacks_spec.rb
+++ b/spec/requests/api/v1/client/attacks_spec.rb
@@ -191,15 +191,15 @@ RSpec.describe "api/v1/client/attacks" do
       end
     end
 
-    it "returns 422 when a NoMethodError occurs" do
+    it "returns 500 when a NoMethodError occurs" do
       create(:task, attack: attack, agent: agent)
       allow(Attack).to receive(:joins).and_raise(NoMethodError.new("undefined method"))
 
       get "/api/v1/client/attacks/#{attack.id}",
           headers: { "Authorization" => "Bearer #{agent.token}", "Accept" => "application/json" }
 
-      expect(response).to have_http_status(:unprocessable_content)
-      expect(response.parsed_body["error"]).to eq("Invalid request")
+      expect(response).to have_http_status(:internal_server_error)
+      expect(response.parsed_body["error"]).to eq("Internal server error")
     end
 
     context "when the attack's campaign association is nil" do
@@ -232,7 +232,7 @@ RSpec.describe "api/v1/client/attacks" do
         get "/api/v1/client/attacks/#{attack.id}",
             headers: { "Accept" => "application/json" }
 
-        expect(response).to have_http_status(:unprocessable_content)
+        expect(response).to have_http_status(:internal_server_error)
         expect(Rails.logger).to have_received(:error).with(/unknown/)
       end
     end

--- a/spec/requests/error_handling_spec.rb
+++ b/spec/requests/error_handling_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText:  2024 UncleSp1d3r
+# SPDX-License-Identifier: MPL-2.0
+
+require "rails_helper"
+
+RSpec.describe "Error Handling" do
+  let(:admin) {
+    user = create(:user)
+    user.add_role(:admin)
+    user
+  }
+
+  describe "unknown_error handler" do
+    context "when in non-production environment" do
+      it "re-raises StandardError so programming bugs surface naturally" do
+        sign_in(admin)
+        allow_any_instance_of(TasksController).to receive(:set_task).and_raise(StandardError.new("test bug")) # rubocop:disable RSpec/AnyInstance
+
+        expect {
+          get task_path(id: 1)
+        }.to raise_error(StandardError, "test bug")
+      end
+    end
+
+    context "when in production environment" do
+      it "renders the unknown error page with 500 status" do
+        sign_in(admin)
+        allow(Rails.env).to receive(:production?).and_return(true)
+        allow_any_instance_of(TasksController).to receive(:set_task).and_raise(StandardError.new("production bug")) # rubocop:disable RSpec/AnyInstance
+
+        get task_path(id: 1)
+
+        expect(response).to have_http_status(:internal_server_error)
+        expect(response).to render_template("errors/unknown_error")
+      end
+
+      it "renders JSON error for JSON requests" do
+        sign_in(admin)
+        allow(Rails.env).to receive(:production?).and_return(true)
+        allow_any_instance_of(TasksController).to receive(:set_task).and_raise(StandardError.new("production bug")) # rubocop:disable RSpec/AnyInstance
+
+        get task_path(id: 1), headers: { "Accept" => "application/json" }
+
+        expect(response).to have_http_status(:internal_server_error)
+        expect(response.parsed_body["error"]).to eq("Unknown Error")
+      end
+    end
+  end
+end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe "Tasks" do
           allow_any_instance_of(Turbo::Streams::TagBuilder).to receive(:update).and_raise(StandardError.new("render error")) # rubocop:disable RSpec/AnyInstance
           expect {
             post cancel_task_path(task), as: :turbo_stream
-          }.to raise_error(ActionController::RespondToMismatchError)
+          }.to raise_error(StandardError, "render error")
           expect(Rails.logger).to have_received(:error).with(/Failed to render Turbo Stream for task #{task.id}/)
         end
 


### PR DESCRIPTION
## Summary

- Remove the dedicated `NoMethodError` rescue in `Api::V1::BaseController` that incorrectly returned 422 for programming bugs — it now falls through to the `StandardError` catch-all returning 500 with proper logging
- Make `ApplicationController#unknown_error` re-raise in dev/test so programming errors surface naturally instead of being silently converted to generic 500 responses
- Add clarifying comment in `Api::V1::BaseController` documenting the intentional asymmetry: API controllers always return structured JSON errors (even in dev/test) since agents need structured responses

## Test plan

- [x] New `spec/requests/error_handling_spec.rb` verifies `unknown_error` re-raises in non-production and renders 500 in production (HTML and JSON)
- [x] Updated `spec/requests/api/v1/client/attacks_spec.rb` to expect 500 instead of 422 for `NoMethodError`
- [x] Updated `spec/requests/tasks_spec.rb` to expect `StandardError` propagation instead of `RespondToMismatchError`
- [x] All 81 affected tests pass

Closes #500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling consistency across the application
  * Enhanced HTTP error responses for API requests
  * Optimized error handling behavior between production and development environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->