### PR TITLE
fix: require lgtm label and lint_api check in Mergify merge conditions

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,9 +3,13 @@ queue_rules:
     merge_method: squash
     merge_conditions:
       - check-success = lint
+      - check-success = lint_api
       - check-success = scan_ruby
       - check-success = test
       - check-success = DCO
+      - or:
+          - label = lgtm
+          - author = dependabot[bot]
     autoqueue: true
 pull_request_rules:
   - name: Queue maintainer PRs with lgtm label
@@ -65,6 +69,7 @@ merge_protections:
       - base = main
     success_conditions:
       - check-success = lint
+      - check-success = lint_api
       - check-success = scan_ruby
       - check-success = test
       - check-success = DCO


### PR DESCRIPTION
## Summary

- Add `lgtm` label requirement to queue `merge_conditions` as a safety net — PRs in the queue won't merge without the label (with exception for dependabot)
- Add `check-success = lint_api` to both `merge_conditions` and `merge_protections` to enforce the new OpenAPI linting CI job before merge

This was prompted by PR #603 merging without the `lgtm` label. The `pull_request_rules` already required the label for queue entry, but `merge_conditions` (the final gate) did not enforce it.

## Test plan

- [ ] Verify Mergify validates the config on this PR
- [ ] After merge, confirm PRs without `lgtm` label are blocked from merging
- [ ] Confirm dependabot PRs still auto-merge without `lgtm`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request merge automation with additional quality validation checks
  * Added support for automated merging of dependency updates when approval conditions are met

<!-- end of auto-generated comment: release notes by coderabbit.ai -->