### PR TITLE
refactor: restructure Mergify merge queue rules by author type

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,27 +1,79 @@
 queue_rules:
-  - name: default
+  # Dosubot: only needs lint to pass
+  - name: dosubot
     merge_method: squash
+    autoqueue: true
+    queue_conditions:
+      - author = dosubot[bot]
+      - base = main
+      - label != do-not-merge
+    merge_conditions:
+      - check-success = lint
+
+  # Dependabot workflow-only changes: only needs lint to pass
+  - name: dependabot-workflows
+    merge_method: squash
+    autoqueue: true
+    queue_conditions:
+      - author = dependabot[bot]
+      - base = main
+      - label != do-not-merge
+      - "-files ~= ^(?!\\.github/workflows/)"
+    merge_conditions:
+      - check-success = lint
+
+  # Dependabot non-workflow changes: full merge protections required
+  - name: dependabot
+    merge_method: squash
+    autoqueue: true
+    queue_conditions:
+      - author = dependabot[bot]
+      - base = main
+      - label != do-not-merge
     merge_conditions:
       - check-success = lint
       - check-success = lint_api
       - check-success = scan_ruby
       - check-success = test
       - check-success = DCO
-      - or:
-          - label = lgtm
-          - author = dependabot[bot]
+
+  # Maintainer: merge protections + lgtm label
+  - name: maintainer
+    merge_method: squash
     autoqueue: true
     queue_conditions:
-      - and:
-          - label = lgtm
-          - author = @unclesp1d3r
-      - or:
-          - author = dosubot[bot]
-          - author = dependabot[bot]
-    batch_size: 3
+      - author = unclesp1d3r
+      - base = main
+      - label = lgtm
+      - label != do-not-merge
+    merge_conditions:
+      - check-success = lint
+      - check-success = lint_api
+      - check-success = scan_ruby
+      - check-success = test
+      - check-success = DCO
+
+  # External contributors: merge protections + approved review
+  - name: external
+    merge_method: squash
+    autoqueue: true
+    queue_conditions:
+      - base = main
+      - author != unclesp1d3r
+      - author != dependabot[bot]
+      - author != dosubot[bot]
+      - label != do-not-merge
+      - branch-protection-review-decision = APPROVED
+    merge_conditions:
+      - check-success = lint
+      - check-success = lint_api
+      - check-success = scan_ruby
+      - check-success = test
+      - check-success = DCO
+
 pull_request_rules:
-  - name: Auto-approve and queue dosubot PRs
-    description: Approve and queue dosubot PRs through the merge queue with full CI
+  - name: Auto-approve dosubot PRs
+    description: Approve dosubot PRs so they can proceed through the queue
     conditions:
       - base = main
       - author = dosubot[bot]
@@ -30,18 +82,9 @@ pull_request_rules:
       review:
         type: APPROVE
         message: Automatically approved by Mergify
-      queue:
-        name: default
-  - name: Queue maintainer PRs with lgtm label
-    conditions:
-      - base = main
-      - author=unclesp1d3r
-      - label = lgtm
-      - label != do-not-merge
-    actions:
-      queue:
-        name: default
-  - name: Auto-approve and queue dependabot PRs
+
+  - name: Auto-approve dependabot PRs
+    description: Approve dependabot PRs so they can proceed through the queue
     conditions:
       - base = main
       - author = dependabot[bot]
@@ -50,27 +93,15 @@ pull_request_rules:
       review:
         type: APPROVE
         message: Automatically approved by Mergify
-      queue:
-        name: default
-  - name: Queue external PRs when approved by maintainer
-    conditions:
-      - base = main
-      - -author=unclesp1d3r
-      - author != dependabot[bot]
-      - approved-reviews-by=unclesp1d3r
-      - label != do-not-merge
-    actions:
-      queue:
-        name: default
+
   - name: Keep PRs up to date with main
     conditions:
       - base = main
       - -conflict
       - -draft
-      - -author = dependabot[bot]
-      - label != do-not-merge
     actions:
       update: {}
+
 merge_protections:
   - name: Enforce conventional commit
     description: Make sure that we follow https://www.conventionalcommits.org/en/v1.0.0/
@@ -82,17 +113,37 @@ merge_protections:
       - "title ~=
         ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\(.+\
         \\))?:"
-  - name: CI must pass
-    description: All CI checks must pass. This protection prevents manual merges
-      that bypass the merge queue.
+
+  - name: Full CI must pass
+    description: All CI checks must pass for non-bot PRs and dependabot non-workflow changes
     if:
       - base = main
+      - or:
+          - and:
+              - author != dependabot[bot]
+              - author != dosubot[bot]
+          - and:
+              - author = dependabot[bot]
+              - "files ~= ^(?!\\.github/workflows/)"
     success_conditions:
       - check-success = lint
       - check-success = lint_api
       - check-success = scan_ruby
       - check-success = test
       - check-success = DCO
+
+  - name: Lint must pass for bots
+    description: At minimum lint must pass for dosubot and dependabot workflow-only changes
+    if:
+      - base = main
+      - or:
+          - author = dosubot[bot]
+          - and:
+              - author = dependabot[bot]
+              - "-files ~= ^(?!\\.github/workflows/)"
+    success_conditions:
+      - check-success = lint
+
   - name: Do not merge outdated PRs
     description: Make sure PRs are within 10 commits of the base branch before merging
     if:


### PR DESCRIPTION
## Summary

- Split single `default` queue into 5 author-specific queues (`dosubot`, `dependabot-workflows`, `dependabot`, `maintainer`, `external`) with tailored CI requirements
- dosubot and dependabot workflow-only PRs require only `lint` to pass; all other PRs require full CI (lint, lint_api, scan_ruby, test, DCO)
- Maintainer PRs require `lgtm` label; external contributor PRs require `APPROVED` review decision
- Merge protections split into "Full CI" and "Lint only" with conditional `if` blocks based on author and changed files
- Update rule now applies to all non-draft, non-conflicting PRs (previously excluded dependabot)
- Removed explicit `queue` actions from pull_request_rules since `autoqueue: true` handles queueing

## Test plan

- [ ] Verify Mergify config is accepted (check Mergify dashboard for validation errors)
- [ ] Test dosubot PR enters `dosubot` queue and merges with lint only
- [ ] Test dependabot workflow-only PR enters `dependabot-workflows` queue with lint only
- [ ] Test dependabot Gemfile PR enters `dependabot` queue with full CI
- [ ] Test maintainer PR requires `lgtm` label + full CI
- [ ] Test external contributor PR requires approved review + full CI
- [ ] Verify non-draft, non-conflicting PRs get auto-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)