### PR TITLE
fix(admin): return 'Forbidden' instead of 'Not Authorized' for 403 responses

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -23,7 +23,7 @@ module Admin
       logger.error "not_authorized #{error}"
       respond_to do |format|
         format.html { render template: "errors/not_authorized", status: :forbidden }
-        format.json { render json: { error: "Not Authorized", status: 403 }, status: :forbidden }
+        format.json { render json: { error: "Forbidden", status: 403 }, status: :forbidden }
         format.all { head :forbidden }
       end
     end


### PR DESCRIPTION
## Summary

Fixes the JSON error message in the admin `not_authorized` handler to use semantically correct HTTP terminology.

- **Before:** `{"error": "Not Authorized", "status": 403}` — misleading; "Not Authorized" implies 401 (authentication failure)
- **After:** `{"error": "Forbidden", "status": 403}` — correct; "Forbidden" matches the 403 status code (authorization failure)

Closes #686

## Context

Per [RFC 9110 §15.5.4](https://www.rfc-editor.org/rfc/rfc9110#section-15.5.4), HTTP 403 means the server understood the request but refuses to fulfill it — the client is authenticated but lacks permission. The previous message conflated this with 401 Unauthorized (authentication failure), which could confuse API consumers.

The HTML response (`errors/not_authorized` template) and the HTTP status code (`:forbidden`) were already correct — only the JSON message string was inconsistent.

## Change

| File | Change |
|------|--------|
| `app/controllers/admin/application_controller.rb` | `"Not Authorized"` → `"Forbidden"` in JSON response |

**1 file changed, 1 insertion, 1 deletion**

## Risk Assessment

**Risk: Low** — Single string change in an error response path. No behavioral, routing, or authorization logic changes.

## Test Plan

- [x] Full RSpec suite passes (1717 examples, 0 failures)
- [ ] `GET /admin` as non-admin user with `Accept: application/json` returns `{"error": "Forbidden", "status": 403}`
- [ ] `GET /admin` as non-admin user in browser still renders the `not_authorized` HTML template with 403 status

🤖 Generated with [Claude Code](https://claude.com/claude-code)