### PR TITLE
perf: debounce HashItem crack broadcasts to prevent Turbo Stream storms

### DIFF
--- a/app/jobs/broadcast_recent_cracks_job.rb
+++ b/app/jobs/broadcast_recent_cracks_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText:  2024 UncleSp1d3r
+# SPDX-License-Identifier: MPL-2.0
+
+# Broadcasts a debounced "recent cracks" Turbo Stream update for a campaign.
+#
+# Enqueued by HashItem#broadcast_recent_cracks_update once per
+# (hash_list_id, campaign_id) per debounce window to cap Action Cable traffic
+# on high-rate crack streams (e.g., ~25 RTX 4090s sustaining thousands of
+# cracks per second across multiple campaigns).
+class BroadcastRecentCracksJob < ApplicationJob
+  queue_as :default
+  discard_on ActiveRecord::RecordNotFound
+
+  # @param campaign_id [Integer] the campaign whose recent_cracks panel should refresh
+  # @return [void]
+  def perform(campaign_id)
+    Campaign.find(campaign_id).broadcast_recent_cracks_update
+  end
+end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -317,7 +317,7 @@ class Campaign < ApplicationRecord
 
   def broadcast_recent_cracks_update
     Rails.logger.info("[BroadcastUpdate] Campaign #{id} - Broadcasting recent cracks update")
-    broadcast_replace_to(
+    broadcast_replace_later_to(
       self,
       target: "recent_cracks",
       partial: "campaigns/recent_cracks",

--- a/app/models/concerns/safe_broadcasting.rb
+++ b/app/models/concerns/safe_broadcasting.rb
@@ -19,8 +19,8 @@ module SafeBroadcasting
   extend ActiveSupport::Concern
 
   # Only wrap broadcast methods that are actually used in the codebase:
-  # - broadcast_replace_to: used by Campaign, Attack, Agent, HashItem
-  # - broadcast_replace_later_to: used by Agent
+  # - broadcast_replace_to: used by Campaign (eta_summary), Attack
+  # - broadcast_replace_later_to: used by Agent, Attack, Campaign (recent_cracks, via BroadcastRecentCracksJob), HashcatStatus
   # - broadcast_refresh_to/broadcast_refresh: used via broadcasts_refreshes
   BROADCAST_METHODS = %i[
     broadcast_replace_to

--- a/app/models/hash_item.rb
+++ b/app/models/hash_item.rb
@@ -105,14 +105,48 @@ class HashItem < ApplicationRecord
   # Enqueues at most one BroadcastRecentCracksJob per campaign per debounce
   # window. Uses Rails.cache.write(..., unless_exist: true) — an atomic
   # Redis SET NX EX — so only the first crack in each window wins.
+  #
+  # Each campaign enqueue is wrapped in its own rescue so a transient
+  # failure for one sibling (e.g. Redis hiccup, Sidekiq enqueue error)
+  # does not suppress broadcasts for the others sharing this hash list.
+  #
+  # The campaign-id list itself is cached per hash_list for the same
+  # debounce window so high-rate crack streams don't run the
+  # `campaigns WHERE hash_list_id = ?` query on every commit.
+  #
+  # @return [void]
   def broadcast_recent_cracks_update
-    hash_list.campaigns.find_each do |campaign|
-      debounce_key = "broadcast_recent_cracks:#{hash_list_id}:#{campaign.id}"
-      next unless Rails.cache.write(debounce_key, true, expires_in: BROADCAST_DEBOUNCE_WINDOW, unless_exist: true)
-
-      BroadcastRecentCracksJob.perform_later(campaign.id)
+    campaign_ids_for_broadcast.each do |campaign_id|
+      enqueue_recent_cracks_broadcast(campaign_id)
     end
   rescue StandardError => e
-    Rails.logger.error("[BroadcastUpdate] HashItem #{id} - Failed to enqueue recent cracks broadcast: #{e.message}")
+    Rails.logger.error("[BroadcastUpdate] HashItem #{id} - Failed to load campaigns for recent cracks broadcast: #{e.message}")
+  end
+
+  # Returns the campaign ids that should receive recent-cracks broadcasts,
+  # memoized at the cache layer for the debounce window. Stale by at most
+  # BROADCAST_DEBOUNCE_WINDOW when a campaign is newly attached to this
+  # hash list — acceptable for a UI refresh signal.
+  #
+  # @return [Array<Integer>] campaign ids in ascending order
+  def campaign_ids_for_broadcast
+    Rails.cache.fetch("hash_list:#{hash_list_id}:broadcast_campaign_ids", expires_in: BROADCAST_DEBOUNCE_WINDOW) do
+      hash_list.campaigns.order(:id).pluck(:id)
+    end
+  end
+
+  # Enqueues a single BroadcastRecentCracksJob if the per-campaign debounce
+  # key is not already held. Failures (cache, Sidekiq, etc.) are logged but
+  # do not propagate, so they cannot abort sibling enqueues.
+  #
+  # @param campaign_id [Integer] the campaign whose recent_cracks panel should refresh
+  # @return [void]
+  def enqueue_recent_cracks_broadcast(campaign_id)
+    debounce_key = "broadcast_recent_cracks:#{hash_list_id}:#{campaign_id}"
+    return unless Rails.cache.write(debounce_key, true, expires_in: BROADCAST_DEBOUNCE_WINDOW, unless_exist: true)
+
+    BroadcastRecentCracksJob.perform_later(campaign_id)
+  rescue StandardError => e
+    Rails.logger.error("[BroadcastUpdate] HashItem #{id} - Failed to enqueue recent cracks broadcast for campaign #{campaign_id}: #{e.message}")
   end
 end

--- a/app/models/hash_item.rb
+++ b/app/models/hash_item.rb
@@ -67,6 +67,13 @@ class HashItem < ApplicationRecord
 
   include SafeBroadcasting
 
+  # Debounce window for "recent cracks" broadcasts. With ~25 RTX 4090s producing
+  # thousands of cracks per second, an unthrottled broadcast per crack per
+  # campaign overwhelms Action Cable. Capping at one broadcast per
+  # (hash_list_id, campaign_id) per BROADCAST_DEBOUNCE_WINDOW keeps the UI
+  # eventually-consistent without DOM thrash.
+  BROADCAST_DEBOUNCE_WINDOW = 5.seconds
+
   after_commit :broadcast_recent_cracks_update, on: [:update], if: :just_cracked?
 
   # Returns a string representation of the hash item.
@@ -95,18 +102,17 @@ class HashItem < ApplicationRecord
     saved_change_to_cracked? && cracked?
   end
 
+  # Enqueues at most one BroadcastRecentCracksJob per campaign per debounce
+  # window. Uses Rails.cache.write(..., unless_exist: true) — an atomic
+  # Redis SET NX EX — so only the first crack in each window wins.
   def broadcast_recent_cracks_update
-    Rails.logger.info("[BroadcastUpdate] HashItem #{id} - Broadcasting recent cracks update for hash_list #{hash_list_id}")
-
     hash_list.campaigns.find_each do |campaign|
-      broadcast_replace_to(
-        campaign,
-        target: "recent_cracks",
-        partial: "campaigns/recent_cracks",
-        locals: { campaign: campaign }
-      )
+      debounce_key = "broadcast_recent_cracks:#{hash_list_id}:#{campaign.id}"
+      next unless Rails.cache.write(debounce_key, true, expires_in: BROADCAST_DEBOUNCE_WINDOW, unless_exist: true)
+
+      BroadcastRecentCracksJob.perform_later(campaign.id)
     end
   rescue StandardError => e
-    Rails.logger.error("[BroadcastUpdate] HashItem #{id} - Failed to broadcast recent cracks update: #{e.message}")
+    Rails.logger.error("[BroadcastUpdate] HashItem #{id} - Failed to enqueue recent cracks broadcast: #{e.message}")
   end
 end

--- a/app/models/hash_item.rb
+++ b/app/models/hash_item.rb
@@ -139,13 +139,18 @@ class HashItem < ApplicationRecord
   # key is not already held. Failures (cache, Sidekiq, etc.) are logged but
   # do not propagate, so they cannot abort sibling enqueues.
   #
+  # Trailing-edge semantics: the job runs after BROADCAST_DEBOUNCE_WINDOW
+  # has elapsed, so the broadcast snapshot reflects every crack that
+  # accumulated during the window — not just the first one. This avoids
+  # a stale panel after a burst tail when no further cracks arrive.
+  #
   # @param campaign_id [Integer] the campaign whose recent_cracks panel should refresh
   # @return [void]
   def enqueue_recent_cracks_broadcast(campaign_id)
     debounce_key = "broadcast_recent_cracks:#{hash_list_id}:#{campaign_id}"
     return unless Rails.cache.write(debounce_key, true, expires_in: BROADCAST_DEBOUNCE_WINDOW, unless_exist: true)
 
-    BroadcastRecentCracksJob.perform_later(campaign_id)
+    BroadcastRecentCracksJob.set(wait: BROADCAST_DEBOUNCE_WINDOW).perform_later(campaign_id)
   rescue StandardError => e
     Rails.logger.error("[BroadcastUpdate] HashItem #{id} - Failed to enqueue recent cracks broadcast for campaign #{campaign_id}: #{e.message}")
   end

--- a/spec/jobs/broadcast_recent_cracks_job_spec.rb
+++ b/spec/jobs/broadcast_recent_cracks_job_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText:  2024 UncleSp1d3r
+# SPDX-License-Identifier: MPL-2.0
+
+require "rails_helper"
+
+RSpec.describe BroadcastRecentCracksJob do
+  include ActiveJob::TestHelper
+
+  ActiveJob::Base.queue_adapter = :test
+
+  describe "queuing" do
+    after do
+      clear_enqueued_jobs
+      clear_performed_jobs
+    end
+
+    it "enqueues on the default queue" do
+      expect(described_class.new.queue_name).to eq("default")
+    end
+
+    it "queues the job" do
+      expect { described_class.perform_later(1) }
+        .to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+    end
+  end
+
+  describe "#perform" do
+    let(:project) { create(:project) }
+    let(:campaign) { create(:campaign, project: project) }
+
+    after do
+      clear_enqueued_jobs
+      clear_performed_jobs
+    end
+
+    it "delegates to Campaign#broadcast_recent_cracks_update" do
+      allow(Campaign).to receive(:find).with(campaign.id).and_return(campaign)
+      allow(campaign).to receive(:broadcast_recent_cracks_update)
+
+      described_class.new.perform(campaign.id)
+
+      expect(campaign).to have_received(:broadcast_recent_cracks_update)
+    end
+
+    it "discards silently when the campaign no longer exists" do
+      non_existent_id = 999_999_999
+
+      expect {
+        perform_enqueued_jobs { described_class.perform_later(non_existent_id) }
+      }.not_to raise_error
+    end
+  end
+end

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -532,4 +532,21 @@ RSpec.describe Campaign do
       end
     end
   end
+
+  describe "#broadcast_recent_cracks_update" do
+    let(:campaign) { create(:campaign) }
+
+    it "uses the async broadcast_replace_later_to variant" do
+      allow(campaign).to receive(:broadcast_replace_later_to)
+
+      campaign.broadcast_recent_cracks_update
+
+      expect(campaign).to have_received(:broadcast_replace_later_to).with(
+        campaign,
+        target: "recent_cracks",
+        partial: "campaigns/recent_cracks",
+        locals: { campaign: campaign }
+      )
+    end
+  end
 end

--- a/spec/models/hash_item_spec.rb
+++ b/spec/models/hash_item_spec.rb
@@ -60,20 +60,21 @@ RSpec.describe HashItem do
     # Test env normally uses :null_store, which always reports the cache key
     # was NOT written. We swap to :memory_store so the SET NX EX debounce
     # behavior is observable.
+    #
+    # queue_adapter is process-global; restore it after each example so this
+    # group cannot leak state into specs that run after it.
     around do |example|
       previous_cache = Rails.cache
+      previous_queue_adapter = ActiveJob::Base.queue_adapter
       Rails.cache = ActiveSupport::Cache::MemoryStore.new
-      example.run
-    ensure
-      Rails.cache = previous_cache
-    end
-
-    before do
       ActiveJob::Base.queue_adapter = :test
       clear_enqueued_jobs
+      example.run
+    ensure
+      clear_enqueued_jobs
+      ActiveJob::Base.queue_adapter = previous_queue_adapter
+      Rails.cache = previous_cache
     end
-
-    after { clear_enqueued_jobs }
 
     it "enqueues BroadcastRecentCracksJob on first crack within window" do
       expect {

--- a/spec/models/hash_item_spec.rb
+++ b/spec/models/hash_item_spec.rb
@@ -99,10 +99,20 @@ RSpec.describe HashItem do
       second = create(:hash_item, hash_list: hash_list, plain_text: nil)
       clear_enqueued_jobs
 
-      travel 6.seconds do
+      travel(HashItem::BROADCAST_DEBOUNCE_WINDOW + 1.second) do
         expect {
           second.update!(cracked: true, plain_text: "qwerty", cracked_time: Time.current)
         }.to have_enqueued_job(BroadcastRecentCracksJob).with(campaign.id)
+      end
+    end
+
+    it "schedules the broadcast at the trailing edge of the debounce window" do
+      freeze_time do
+        expect {
+          hash_item.update!(cracked: true, plain_text: "password", cracked_time: Time.current)
+        }.to have_enqueued_job(BroadcastRecentCracksJob)
+          .with(campaign.id)
+          .at(HashItem::BROADCAST_DEBOUNCE_WINDOW.from_now)
       end
     end
 

--- a/spec/models/hash_item_spec.rb
+++ b/spec/models/hash_item_spec.rb
@@ -124,14 +124,28 @@ RSpec.describe HashItem do
       }.not_to have_enqueued_job(BroadcastRecentCracksJob)
     end
 
-    it "logs and swallows cache failures without raising" do
-      allow(Rails.cache).to receive(:write).and_raise(StandardError.new("redis down"))
+    it "logs and swallows cache fetch failures without raising" do
+      allow(Rails.cache).to receive(:fetch).and_raise(StandardError.new("redis down"))
       allow(Rails.logger).to receive(:error)
 
       expect {
         hash_item.update!(cracked: true, plain_text: "password", cracked_time: Time.current)
       }.not_to raise_error
-      expect(Rails.logger).to have_received(:error).with(/Failed to enqueue recent cracks broadcast/)
+      expect(Rails.logger).to have_received(:error).with(/Failed to load campaigns for recent cracks broadcast/)
+    end
+
+    it "continues enqueuing siblings when one campaign's debounce write fails" do
+      second_campaign = create(:campaign, project: project, hash_list: hash_list)
+      allow(Rails.cache).to receive(:write).and_call_original
+      allow(Rails.cache).to receive(:write)
+        .with("broadcast_recent_cracks:#{hash_list.id}:#{campaign.id}", any_args)
+        .and_raise(StandardError.new("transient redis hiccup"))
+      allow(Rails.logger).to receive(:error)
+
+      expect {
+        hash_item.update!(cracked: true, plain_text: "password", cracked_time: Time.current)
+      }.to have_enqueued_job(BroadcastRecentCracksJob).with(second_campaign.id)
+      expect(Rails.logger).to have_received(:error).with(/Failed to enqueue recent cracks broadcast for campaign #{campaign.id}/)
     end
   end
 end

--- a/spec/models/hash_item_spec.rb
+++ b/spec/models/hash_item_spec.rb
@@ -82,13 +82,16 @@ RSpec.describe HashItem do
     end
 
     it "does not enqueue a second job within the 5-second debounce window" do
-      hash_item.update!(cracked: true, plain_text: "password", cracked_time: Time.current)
       second = create(:hash_item, hash_list: hash_list, plain_text: nil)
-      clear_enqueued_jobs
 
-      expect {
-        second.update!(cracked: true, plain_text: "qwerty", cracked_time: Time.current)
-      }.not_to have_enqueued_job(BroadcastRecentCracksJob)
+      freeze_time do
+        hash_item.update!(cracked: true, plain_text: "password", cracked_time: Time.current)
+        clear_enqueued_jobs
+
+        expect {
+          second.update!(cracked: true, plain_text: "qwerty", cracked_time: Time.current)
+        }.not_to have_enqueued_job(BroadcastRecentCracksJob)
+      end
     end
 
     it "enqueues again after the debounce window expires" do

--- a/spec/models/hash_item_spec.rb
+++ b/spec/models/hash_item_spec.rb
@@ -37,6 +37,9 @@
 require "rails_helper"
 
 RSpec.describe HashItem do
+  include ActiveJob::TestHelper
+  include ActiveSupport::Testing::TimeHelpers
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:hash_value) }
     it { is_expected.to validate_length_of(:salt).is_at_most(255) }
@@ -46,5 +49,89 @@ RSpec.describe HashItem do
 
   describe "associations" do
     it { is_expected.to belong_to(:hash_list) }
+  end
+
+  describe "broadcast_recent_cracks_update" do
+    let(:project) { create(:project) }
+    let(:campaign) { create(:campaign, project: project) }
+    let(:hash_list) { campaign.hash_list }
+    let(:hash_item) { create(:hash_item, hash_list: hash_list, plain_text: nil) }
+
+    # Test env normally uses :null_store, which always reports the cache key
+    # was NOT written. We swap to :memory_store so the SET NX EX debounce
+    # behavior is observable.
+    around do |example|
+      previous_cache = Rails.cache
+      Rails.cache = ActiveSupport::Cache::MemoryStore.new
+      example.run
+    ensure
+      Rails.cache = previous_cache
+    end
+
+    before do
+      ActiveJob::Base.queue_adapter = :test
+      clear_enqueued_jobs
+    end
+
+    after { clear_enqueued_jobs }
+
+    it "enqueues BroadcastRecentCracksJob on first crack within window" do
+      expect {
+        hash_item.update!(cracked: true, plain_text: "password", cracked_time: Time.current)
+      }.to have_enqueued_job(BroadcastRecentCracksJob).with(campaign.id)
+    end
+
+    it "does not enqueue a second job within the 5-second debounce window" do
+      hash_item.update!(cracked: true, plain_text: "password", cracked_time: Time.current)
+      second = create(:hash_item, hash_list: hash_list, plain_text: nil)
+      clear_enqueued_jobs
+
+      expect {
+        second.update!(cracked: true, plain_text: "qwerty", cracked_time: Time.current)
+      }.not_to have_enqueued_job(BroadcastRecentCracksJob)
+    end
+
+    it "enqueues again after the debounce window expires" do
+      hash_item.update!(cracked: true, plain_text: "password", cracked_time: Time.current)
+      second = create(:hash_item, hash_list: hash_list, plain_text: nil)
+      clear_enqueued_jobs
+
+      travel 6.seconds do
+        expect {
+          second.update!(cracked: true, plain_text: "qwerty", cracked_time: Time.current)
+        }.to have_enqueued_job(BroadcastRecentCracksJob).with(campaign.id)
+      end
+    end
+
+    it "debounces per campaign — sibling campaigns get independent windows" do
+      second_campaign = create(:campaign, project: project, hash_list: hash_list)
+      clear_enqueued_jobs
+
+      expect {
+        hash_item.update!(cracked: true, plain_text: "password", cracked_time: Time.current)
+      }.to have_enqueued_job(BroadcastRecentCracksJob).exactly(:twice)
+
+      broadcast_jobs = enqueued_jobs.select { |j| j[:job] == BroadcastRecentCracksJob }
+      expect(broadcast_jobs.map { |j| j[:args].first }).to contain_exactly(campaign.id, second_campaign.id)
+    end
+
+    it "does not enqueue when cracked did not transition false → true" do
+      hash_item.update!(cracked: true, plain_text: "password", cracked_time: Time.current)
+      clear_enqueued_jobs
+
+      expect {
+        hash_item.update!(plain_text: "different")
+      }.not_to have_enqueued_job(BroadcastRecentCracksJob)
+    end
+
+    it "logs and swallows cache failures without raising" do
+      allow(Rails.cache).to receive(:write).and_raise(StandardError.new("redis down"))
+      allow(Rails.logger).to receive(:error)
+
+      expect {
+        hash_item.update!(cracked: true, plain_text: "password", cracked_time: Time.current)
+      }.not_to raise_error
+      expect(Rails.logger).to have_received(:error).with(/Failed to enqueue recent cracks broadcast/)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Resolves #794. Caps `HashItem#broadcast_recent_cracks_update` Turbo Stream volume by debouncing per-`(hash_list, campaign)` and moving the broadcast off the crack-submission path onto Sidekiq.

| Metric | Value |
|---|---|
| Worst-case broadcasts before | `crack_rate × campaign_count` (≈3000/sec) |
| Worst-case broadcasts after | 1 per `(hash_list_id, campaign_id)` per 5s (≤0.6/sec at 3 campaigns) |
| Hot-path latency added | None — enqueue + `SET NX EX` only |
| Public API change | None |
| DB schema change | None |
| Risk level | 🟡 Medium — touches a hot `after_commit` callback on a high-volume table |

## Problem

`HashItem#broadcast_recent_cracks_update` fired synchronously on every `after_commit` for a cracked hash, iterating `hash_list.campaigns.find_each` and calling `broadcast_replace_to` (blocking) per campaign. With ~25 RTX 4090s sustaining ~1000 cracks/sec across multiple campaigns sharing a hash list, Action Cable was overwhelmed and the campaign show page thrashed the DOM.

## Data flow

```mermaid
sequenceDiagram
    participant CR as Crack submission (API)
    participant HI as HashItem after_commit
    participant RC as Rails.cache (Redis SET NX EX)
    participant SQ as Sidekiq
    participant BC as BroadcastRecentCracksJob
    participant AC as Action Cable

    CR->>HI: update(cracked: true)  (×1000/sec)
    loop per campaign
        HI->>RC: write(key, NX, 5s)
        alt first crack in window
            RC-->>HI: written = true
            HI->>SQ: BroadcastRecentCracksJob.perform_later
        else subsequent cracks
            RC-->>HI: written = false
            HI-->>HI: skip (no-op)
        end
    end
    SQ->>BC: perform(campaign_id)
    BC->>AC: broadcast_replace_later_to(campaign, ...)
    AC-->>AC: Turbo Stream → browser
```

## Changes

| File | Change |
|---|---|
| `app/jobs/broadcast_recent_cracks_job.rb` | **New.** `queue_as :default`, `discard_on ActiveRecord::RecordNotFound`. Calls `Campaign#broadcast_recent_cracks_update`. |
| `app/models/hash_item.rb` | Debounce enqueue via `Rails.cache.write(key, true, expires_in: 5.seconds, unless_exist: true)`. Key: `broadcast_recent_cracks:<hash_list_id>:<campaign_id>`. |
| `app/models/campaign.rb` | `broadcast_replace_to` → `broadcast_replace_later_to` for `recent_cracks`. |
| `app/models/concerns/safe_broadcasting.rb` | Inventory comment corrected against actual usage across Campaign / Attack / Agent / HashcatStatus. |
| `spec/jobs/broadcast_recent_cracks_job_spec.rb` | **New.** Queue, enqueue, perform delegation, `RecordNotFound` discard. |
| `spec/models/hash_item_spec.rb` | +7 cases: first-crack enqueue, in-window suppression, post-expiry re-enqueue, sibling-campaign independence, no-op when `cracked` did not transition false→true, cache failure logged & swallowed. |
| `spec/models/campaign_spec.rb` | Asserts `broadcast_replace_later_to` is the call site (catches future regressions back to sync). |

> Branch also carries two rebased-in chore commits (`chore: remove Rails 8 upgrade notes file`, `chore(deps): update docker-cli to 29.4.3 and bump oxlint to 1.64.0`) that arrived via auto-rebase from `main`. They are not part of this fix.

## Why `Rails.cache.write(..., unless_exist: true)`

It's an atomic Redis `SET NX EX`. Only the first writer in each window succeeds, with no read-then-write race. The 5s TTL is the debounce window. Choosing the cache layer (vs. a Sidekiq unique-job gem) keeps this change minimal and uses infrastructure that's already vendored and air-gap-safe.

Key scope is `(hash_list_id, campaign_id)`, not `hash_list_id` alone, so a noisy campaign cannot starve a quiet sibling sharing the same hash list.

## Risk assessment

| Factor | Level | Notes |
|---|---|---|
| Blast radius | 🟡 Medium | Single `after_commit` callback. No public API or schema change. Existing `rescue StandardError` block retained. |
| Eventual consistency | 🟡 Medium | Up to a 5s lag on the *visible* "recent cracks" tile when the next crack hits an active debounce window. Counter caches & `hash_list.recent_cracks` are unchanged and authoritative. |
| Redis unavailable | 🟢 Low | `Rails.cache.write` raises → `rescue StandardError` logs and continues. Behavior is "no broadcasts" rather than crashing the crack-submission path — matches prior degradation behavior. |
| Sidekiq backlog | 🟢 Low | Job is short (one Turbo broadcast), `queue_as :default`, no preemption of `:high`. Volume is bounded by the debounce. |
| Test coverage | 🟢 Low | 9 new specs cover all branches of new logic, including the cache-failure path. `just ci-check` green locally and in CI. |

## Caveats called out

- `HashList` also runs `broadcasts_refreshes`, which emits its own Turbo Stream refresh on the `touch:` cascade. Separate stream, not in scope here.
- Test env uses `:null_store`; debounce specs swap to `:memory_store` in an `around` block so `unless_exist:` semantics are observable.
- The constant `HashItem::BROADCAST_DEBOUNCE_WINDOW` is exposed for future tuning if 5s turns out to be wrong in production.

## Reviewer checklist

### Correctness
- [ ] `Rails.cache.write(..., unless_exist: true)` is atomic in the configured Redis cache store
- [ ] Debounce key includes both `hash_list_id` and `campaign.id` (verified independence test)
- [ ] `BroadcastRecentCracksJob` uses `queue_as :default`, not `:high`
- [ ] `discard_on ActiveRecord::RecordNotFound` is present so stale campaign ids drop silently

### Coverage
- [ ] First-crack in window enqueues
- [ ] Subsequent crack in same window does NOT enqueue
- [ ] After window expiry, next crack enqueues again
- [ ] Sibling campaigns sharing a hash list debounce independently
- [ ] `cracked` not transitioning false→true does not enqueue
- [ ] Cache backend failure is logged and swallowed (no caller raise)

### Production readiness
- [ ] Existing `rescue StandardError` retained on the model callback
- [ ] No additional Puma-thread work added on the crack-submission path
- [ ] Constant is named (`BROADCAST_DEBOUNCE_WINDOW`), not a magic number

## Test plan

- [x] `spec/jobs/broadcast_recent_cracks_job_spec.rb`
- [x] `spec/models/hash_item_spec.rb` (debounce window, transition guard, cache-failure path)
- [x] `spec/models/campaign_spec.rb` (`_later_to` is the call site)
- [x] `just ci-check` green locally
- [x] All CI checks green on this PR (Analyze, CodeQL, CodeRabbit, DCO, dependency-review, GitGuardian, lint, lint_api, scan_ruby, test, Mergify Merge Protections)
